### PR TITLE
Add overloads to MongoDbRunner Start and StartForDebugging methods wh…

### DIFF
--- a/src/Mongo2Go/MongoDbRunner.cs
+++ b/src/Mongo2Go/MongoDbRunner.cs
@@ -36,6 +36,17 @@ namespace Mongo2Go
             return new MongoDbRunner(PortPool.GetInstance, new FileSystem(), new MongoDbProcessStarter(), new MongoBinaryLocator(searchPatternOverride), dataDirectory);
         }
 
+       
+        public static MongoDbRunner Start(IMongoBinaryLocator mongoBinaryLocator, string dataDirectory = MongoDbDefaults.DataDirectory)
+        {
+            if (mongoBinaryLocator == null) throw new ArgumentNullException(nameof(mongoBinaryLocator));
+
+            dataDirectory += Guid.NewGuid().ToString().Replace("-", "").Substring(0, 20);
+
+            return new MongoDbRunner(PortPool.GetInstance, new FileSystem(), new MongoDbProcessStarter(), mongoBinaryLocator, dataDirectory);
+        }
+
+
         internal static MongoDbRunner StartUnitTest(IPortPool portPool, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin)
         {
             return new MongoDbRunner(portPool, fileSystem, processStarter, mongoBin, MongoDbDefaults.DataDirectory);
@@ -52,6 +63,16 @@ namespace Mongo2Go
         {
             return new MongoDbRunner(new ProcessWatcher(), new PortWatcher(), new FileSystem(), new MongoDbProcessStarter(), new MongoBinaryLocator(searchPatternOverride), dataDirectory);
         }
+
+        
+       
+        public static MongoDbRunner StartForDebugging(IMongoBinaryLocator mongoBinaryLocator, string dataDirectory = MongoDbDefaults.DataDirectory)
+        {
+            if (mongoBinaryLocator == null) throw new ArgumentNullException(nameof(mongoBinaryLocator));
+
+            return new MongoDbRunner(new ProcessWatcher(), new PortWatcher(), new FileSystem(), new MongoDbProcessStarter(), mongoBinaryLocator, dataDirectory);
+        }
+
 
         internal static MongoDbRunner StartForDebuggingUnitTest(IProcessWatcher processWatcher, IPortWatcher portWatcher, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin)
         {


### PR DESCRIPTION
…ere an instance of IMongoBinaryLocator is accepted as argument. This is needed when running under the new .NET Core platform (e.g, via the "dotnet run" or "dotnet test" commands) since the MongoDB are located under e.g., C:\Users\FooUser\.nuget\packages\Mongo2Go\1.0.0\tools\mongodb-win32-x86_64-2008plus-3.2.7\bin which is not a relative path to the currently executing assembly and hence cannot be easily specified as searchPatternOverride parameter which only accepts relative paths