### PR TITLE
Fix tests for platforms other than Windows

### DIFF
--- a/src/Mongo2Go/Helper/FileSystem.cs
+++ b/src/Mongo2Go/Helper/FileSystem.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Diagnostics;
+using System.IO;
 
 namespace Mongo2Go.Helper
 {
@@ -31,7 +32,13 @@ namespace Mongo2Go.Helper
         public void MakeFileExecutable (string path) 
         {
             //when on linux or osx we must set the executeble flag on mongo binarys
-            File.SetAttributes (path, (FileAttributes)((int)File.GetAttributes (path) | 0x80000000));
+            var p = Process.Start("chmod", $"+x {path}");
+            p.WaitForExit();
+
+            if (p.ExitCode != 0) 
+            {
+                throw new IOException($"Could not set executable bit for {path}");
+            }
         }
     }
 }

--- a/src/Mongo2Go/Helper/MongoImportExport.cs
+++ b/src/Mongo2Go/Helper/MongoImportExport.cs
@@ -17,7 +17,7 @@ namespace Mongo2Go.Helper
                 throw new FileNotFoundException("File not found", finalPath);
             }
             
-            string fileName = @"{0}\{1}".Formatted(binariesDirectory, MongoDbDefaults.MongoImportExecutable);
+            string fileName = Path.Combine("{0}", "{1}").Formatted(binariesDirectory, MongoDbDefaults.MongoImportExecutable);
             string arguments = @"--host localhost --port {0} --db {1} --collection {2} --file ""{3}""".Formatted(port, database, collection, finalPath);
             if (drop) { arguments += " --drop"; }
 
@@ -34,7 +34,7 @@ namespace Mongo2Go.Helper
         {
             string finalPath = FolderSearch.FinalizePath(outputFile);
 
-            string fileName = @"{0}\{1}".Formatted(binariesDirectory, MongoDbDefaults.MongoExportExecutable);
+            string fileName = Path.Combine("{0}", "{1}").Formatted(binariesDirectory, MongoDbDefaults.MongoExportExecutable);
             string arguments = @"--host localhost --port {0} --db {1} --collection {2} --out ""{3}""".Formatted(port, database, collection, finalPath);
 
             Process process = ProcessControl.ProcessFactory(fileName, arguments);

--- a/src/Mongo2Go/MongoDbDefaults.cs
+++ b/src/Mongo2Go/MongoDbDefaults.cs
@@ -15,8 +15,6 @@
         // but we don't want to get in trouble with productive systems
         public const int TestStartPort = 27018;
 
-        public const string DataDirectory = @"C:\data\db";
-
         public const string Lockfile = "mongod.lock";
     }
 }

--- a/src/Mongo2GoTests/FolderSearchTests.cs
+++ b/src/Mongo2GoTests/FolderSearchTests.cs
@@ -13,14 +13,14 @@ namespace Mongo2GoTests
         public static string directory;
 
         Because of = () => directory = FolderSearch.CurrentExecutingDirectory();
-        It should_contain_correct_path = () => directory.Should().Contain(@"Mongo2GoTests\bin");
+        It should_contain_correct_path = () => directory.Should().Contain(Path.Combine("Mongo2GoTests", "bin"));
     }
 
     [Subject("FolderSearch")]
     public class when_searching_for_folder : FolderSearchSpec
     {
-        const string startDirectory = @"C:\test1\test2";
-        const string searchPattern = @"packages\Mongo2Go*\tools\mongodb-win32-i386*\bin";
+        static string startDirectory = Path.Combine(BaseDir, "test1", "test2");
+        static string searchPattern = Path.Combine("packages", "Mongo2Go*", "tools", "mongodb-win32-i386*", "bin");
         static string directory;
 
         Because of = () => directory = startDirectory.FindFolder(searchPattern);
@@ -30,8 +30,8 @@ namespace Mongo2GoTests
     [Subject("FolderSearch")]
     public class when_searching_for_not_existing_folder : FolderSearchSpec
     {
-        const string startDirectory = @"C:\test1\test2";
-        const string searchPattern = @"packages\Mongo2Go*\XXX\mongodb-win32-i386*\bin";
+        static string startDirectory = Path.Combine(BaseDir, "test1", "test2");
+        static string searchPattern = Path.Combine("packages", "Mongo2Go*", "XXX", "mongodb-win32-i386*", "bin");
         static string directory;
 
         Because of = () => directory = startDirectory.FindFolder(searchPattern);
@@ -41,7 +41,7 @@ namespace Mongo2GoTests
     [Subject("FolderSearch")]
     public class when_searching_for_folder_upwards : FolderSearchSpec
     {
-        const string searchPattern = @"packages\Mongo2Go*\tools\mongodb-win32-i386*\bin";
+        static string searchPattern = Path.Combine("packages", "Mongo2Go*", "tools", "mongodb-win32-i386*", "bin");
         static string directory;
 
         Because of = () => directory = LocationOfAssembly.FindFolderUpwards(searchPattern);
@@ -51,7 +51,7 @@ namespace Mongo2GoTests
     [Subject("FolderSearch")]
     public class when_searching_for_not_existing_folder_upwards : FolderSearchSpec
     {
-        const string searchPattern = @"packages\Mongo2Go*\XXX\mongodb-win32-i386*\bin";
+        static string searchPattern = Path.Combine("packages", "Mongo2Go*", "XXX", "mongodb-win32-i386*", "bin");
         static string directory;
 
         Because of = () => directory = LocationOfAssembly.FindFolderUpwards(searchPattern);
@@ -63,8 +63,8 @@ namespace Mongo2GoTests
     {
         static string directory;
 
-        Because of = () => directory = @"test1\test2\test3".RemoveLastPart();
-        It should_remove_the_element = () => directory.Should().Be(@"test1\test2");
+        Because of = () => directory = Path.Combine("test1", "test2", "test3").RemoveLastPart();
+        It should_remove_the_element = () => directory.Should().Be(Path.Combine("test1", "test2"));
     }
 
     [Subject("FolderSearch")]
@@ -78,18 +78,20 @@ namespace Mongo2GoTests
 
     public class FolderSearchSpec
     {
-        public const string MongoBinaries = @"C:\test1\test2\packages\Mongo2Go.1.2.3\tools\mongodb-win32-i386-2.0.7-rc0\bin";
-        public const string MongoOlderBinaries = @"C:\test1\test2\packages\Mongo2Go.1.1.1\tools\mongodb-win32-i386-2.0.7-rc0\bin";
-        public const string LocationOfAssembly = @"C:\test1\test2\Project\bin";
+        public static string BaseDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        public static string MongoBinaries = Path.Combine(BaseDir, "test1", "test2", "packages", "Mongo2Go.1.2.3", "tools", "mongodb-win32-i386-2.0.7-rc0", "bin");
+        public static string MongoOlderBinaries = Path.Combine(BaseDir, "test1", "test2", "packages", "Mongo2Go.1.1.1", "tools", "mongodb-win32-i386-2.0.7-rc0", "bin");
+        public static string LocationOfAssembly = Path.Combine(BaseDir, "test1", "test2", "Project", "bin");
 
         Establish context = () =>
         {
+            if (!Directory.Exists(BaseDir)) { Directory.CreateDirectory(BaseDir); }
             if (!Directory.Exists(MongoBinaries)) { Directory.CreateDirectory(MongoBinaries); }
             if (!Directory.Exists(MongoOlderBinaries)) { Directory.CreateDirectory(MongoOlderBinaries); }
             if (!Directory.Exists(LocationOfAssembly)) { Directory.CreateDirectory(LocationOfAssembly); }
         };
 
-        Cleanup stuff = () => { if (Directory.Exists(@"C:\test1")) { Directory.Delete(@"C:\test1", true); }};
+        Cleanup stuff = () => { if (Directory.Exists(BaseDir)) { Directory.Delete(BaseDir, true); }};
     }
 }
 // ReSharper restore UnusedMember.Local

--- a/src/Mongo2GoTests/Runner/RunnerTests.cs
+++ b/src/Mongo2GoTests/Runner/RunnerTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.IO;
+using FluentAssertions;
 using Machine.Specifications;
 using Mongo2Go;
 using Mongo2Go.Helper;
@@ -18,8 +20,8 @@ namespace Mongo2GoTests.Runner
         static Mock<IMongoDbProcessStarter> processStarterMock;
         static Mock<IMongoBinaryLocator> binaryLocatorMock;
 
-        static readonly string exptectedDataDirectory = "{0}_{1}".Formatted(MongoDbDefaults.DataDirectory, MongoDbDefaults.TestStartPort + 1);
-        static readonly string exptectedLogfile = @"{0}_{1}\{2}".Formatted(MongoDbDefaults.DataDirectory, MongoDbDefaults.TestStartPort + 1, MongoDbDefaults.Lockfile);
+        static string exptectedDataDirectory;
+        static string exptectedLogfile;
         static readonly string exptectedConnectString = "mongodb://localhost:{0}/".Formatted(MongoDbDefaults.TestStartPort + 1);
 
         Establish context = () =>
@@ -28,6 +30,11 @@ namespace Mongo2GoTests.Runner
             portPoolMock.Setup(m => m.GetNextOpenPort()).Returns(MongoDbDefaults.TestStartPort + 1);
 
             fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(m => m.CreateFolder(Moq.It.IsAny<string>())).Callback<string>(s => 
+            {
+                exptectedDataDirectory = s;
+                exptectedLogfile = Path.Combine(exptectedDataDirectory, MongoDbDefaults.Lockfile);
+            });
             
             var processMock = new Mock<IMongoDbProcess>();
 
@@ -35,12 +42,13 @@ namespace Mongo2GoTests.Runner
             processStarterMock.Setup(m => m.Start(Moq.It.IsAny<string>(), Moq.It.IsAny<string>(), Moq.It.IsAny<int>())).Returns(processMock.Object);
 
             binaryLocatorMock = new Mock<IMongoBinaryLocator> ();
-
+            binaryLocatorMock.Setup(m => m.Directory).Returns(string.Empty);
         };
 
         Because of = () => runner = MongoDbRunner.StartUnitTest(portPoolMock.Object, fileSystemMock.Object, processStarterMock.Object, binaryLocatorMock.Object);
 
-        It should_create_the_data_directory             = () => fileSystemMock.Verify(x => x.CreateFolder(exptectedDataDirectory), Times.Exactly(1));
+        string dataDirectory;
+        It should_create_the_data_directory             = () => fileSystemMock.Verify(x => x.CreateFolder(Moq.It.Is<string>(s => s.StartsWith(Path.GetTempPath()))), Times.Exactly(1));
         It should_delete_old_lock_file                  = () => fileSystemMock.Verify(x => x.DeleteFile(exptectedLogfile), Times.Exactly(1));
 
         It should_start_the_process                     = () => processStarterMock.Verify(x => x.Start(Moq.It.IsAny<string>(), Moq.It.IsAny<string>(), Moq.It.IsAny<int>()), Times.Exactly(1));
@@ -59,7 +67,8 @@ namespace Mongo2GoTests.Runner
         static Mock<IMongoDbProcessStarter> processStarterMock;
         static Mock<IMongoBinaryLocator> binaryLocatorMock;
 
-        static readonly string exptectedLogfile = @"{0}\{1}".Formatted(MongoDbDefaults.DataDirectory, MongoDbDefaults.Lockfile);
+        static string exptectedDataDirectory;
+        static string exptectedLogfile;
 
         Establish context = () =>
         {
@@ -70,22 +79,28 @@ namespace Mongo2GoTests.Runner
             portWatcherMock.Setup(m => m.IsPortAvailable(Moq.It.IsAny<int>())).Returns(true);
 
             fileSystemMock = new Mock<IFileSystem>();
+            fileSystemMock.Setup(m => m.CreateFolder(Moq.It.IsAny<string>())).Callback<string>(s => 
+            {
+                exptectedDataDirectory = s;
+                exptectedLogfile = Path.Combine(exptectedDataDirectory, MongoDbDefaults.Lockfile);
+            });
 
             var processMock = new Mock<IMongoDbProcess>();
             processStarterMock = new Mock<IMongoDbProcessStarter>();
-            processStarterMock.Setup(m => m.Start(Moq.It.IsAny<string>(), MongoDbDefaults.DataDirectory, MongoDbDefaults.DefaultPort, true)).Returns(processMock.Object);
+            processStarterMock.Setup(m => m.Start(Moq.It.IsAny<string>(), exptectedDataDirectory, MongoDbDefaults.DefaultPort, true)).Returns(processMock.Object);
 
             binaryLocatorMock = new Mock<IMongoBinaryLocator> ();
+            binaryLocatorMock.Setup(m => m.Directory).Returns(string.Empty);
         };
 
         Because of = () => runner = MongoDbRunner.StartForDebuggingUnitTest(processWatcherMock.Object, portWatcherMock.Object, fileSystemMock.Object, processStarterMock.Object, binaryLocatorMock.Object);
 
         It should_check_for_already_running_process = () => processWatcherMock.Verify(x => x.IsProcessRunning(MongoDbDefaults.ProcessName), Times.Exactly(1));
         It should_check_the_default_port = () => portWatcherMock.Verify(x => x.IsPortAvailable(MongoDbDefaults.DefaultPort), Times.Exactly(1));
-        It should_create_the_data_directory = () => fileSystemMock.Verify(x => x.CreateFolder(MongoDbDefaults.DataDirectory), Times.Exactly(1));
+        It should_create_the_data_directory = () => fileSystemMock.Verify(x => x.CreateFolder(Moq.It.Is<string>(s => s.StartsWith(Path.GetTempPath()))), Times.Exactly(1));
         It should_delete_old_lock_file = () => fileSystemMock.Verify(x => x.DeleteFile(exptectedLogfile), Times.Exactly(1));
 		It should_return_an_instance_with_state_running = () => runner.State.Should().Be(State.Running);
-        It should_start_the_process_without_kill = () => processStarterMock.Verify(x => x.Start(Moq.It.IsAny<string>(), MongoDbDefaults.DataDirectory, MongoDbDefaults.DefaultPort, true), Times.Exactly(1));
+        It should_start_the_process_without_kill = () => processStarterMock.Verify(x => x.Start(Moq.It.IsAny<string>(), exptectedDataDirectory, MongoDbDefaults.DefaultPort, true), Times.Exactly(1));
     }
 }
 // ReSharper restore UnusedMember.Local


### PR DESCRIPTION
This fixes #37 (1515dda043af41e88345b053b2f810cf3670b24f), but also makes the tests run on Linux (and hopefully also OS X).

A lot of paths were hardcoded to use backslash as path separator, which doesn't work on Linux, and also the data path defaulted to use `C:\data\`, which obviously doesn't work on Linux.

This PR make the somewhat intrusive change of removing the `MongoDbDefaults.DataDirectory` constant, and will instead by default create the database in the user's temporary directory, which I think is a better default, although I guess it could be debated.