### PR TITLE
Upgrade to .NET Core 2.0 and update dependencies

### DIFF
--- a/src/Mongo2GoTests/Mongo2GoTests.csproj
+++ b/src/Mongo2GoTests/Mongo2GoTests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Mongo2GoTests</AssemblyName>
     <PackageId>Mongo2GoTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -15,19 +14,17 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Mongo2Go\Mongo2Go.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Machine.Specifications" Version="0.11.0" />
+    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="MongoDB.Bson" Version="2.4.3" />
     <PackageReference Include="MongoDB.Driver" Version="2.4.3" />
     <PackageReference Include="MongoDB.Driver.Core" Version="2.4.3" />
     <PackageReference Include="Moq" Version="4.7.1" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This updates target framework to `netcorapp2.0` and updates dependencies (Machine.Specifications and Microsoft.NET.Test.Sdk). This, in combination with #42, makes the tests possible to run for me on Windows as well as Linux.

I should say I find the combinations of .NET Core and .NET Standard very confusing, so I apologize in advance if I've messed something up. Also, some tool appears to have changed indentation on everything 😞 .