### PR TITLE
Feature/nickmkk 55 nuget packagereference compatibility

### DIFF
--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -91,7 +91,7 @@ namespace Mongo2Go.Helper
             }
             throw new MonogDbBinariesNotFoundException(
                 $"Could not find Mongo binaries using the search patterns \"{_searchPattern}\", \"{Path.Combine(_nugetPrefix, _searchPattern)}\", and \"{Path.Combine(_nugetCachePrefix, _searchPattern)}\".  " +
-                $"You can override the search pattern when calling MongoDbRunner.Start.  We have detected the OS as {RuntimeInformation.OSDescription}.\n" +
+                $"You can override the search pattern and directory when calling MongoDbRunner.Start.  We have detected the OS as {RuntimeInformation.OSDescription}.\n" +
                 $"We walked up to root directory from the following locations.\n {string.Join("\n", searchDirectories)}");
         }
     }

--- a/src/Mongo2Go/MongoDbRunner.cs
+++ b/src/Mongo2Go/MongoDbRunner.cs
@@ -31,7 +31,7 @@ namespace Mongo2Go
         /// On dispose: kills them and deletes their data directory
         /// </summary>
         /// <remarks>Should be used for integration tests</remarks>
-        public static MongoDbRunner Start(string dataDirectory = null, string searchPatternOverride = null)
+        public static MongoDbRunner Start(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null)
         {
             if (dataDirectory == null) {
                 dataDirectory = CreateTemporaryDataDirectory();
@@ -44,7 +44,7 @@ namespace Mongo2Go
                 PortPool.GetInstance,
                 new FileSystem(),
                 new MongoDbProcessStarter(),
-                new MongoBinaryLocator(searchPatternOverride),
+                new MongoBinaryLocator(binariesSearchPatternOverride, binariesSearchDirectory),
                 dataDirectory);
         }
 
@@ -77,14 +77,14 @@ namespace Mongo2Go
         /// Should be used for local debugging only
         /// WARNING: one single instance on one single machine is not a suitable setup for productive environments!!!
         /// </remarks>
-        public static MongoDbRunner StartForDebugging(string dataDirectory = null, string searchPatternOverride = null)
+        public static MongoDbRunner StartForDebugging(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null)
         {
             return new MongoDbRunner(
                 new ProcessWatcher(),
                 new PortWatcher(),
                 new FileSystem(),
                 new MongoDbProcessStarter(),
-                new MongoBinaryLocator(searchPatternOverride), dataDirectory);
+                new MongoBinaryLocator(binariesSearchPatternOverride, binariesSearchDirectory), dataDirectory);
         }
 
         /// <summary>


### PR DESCRIPTION
- I've updated the MongoBinaryLocator to  look for binaries in the nuget cache if they are not found in the project directory.  This will make Mongo2Go compatible with projects using the nuget PackageReference option.  
- Also, I've added a binariesSearchDirectory parameter to MongoDbRunner.Start which allows an additional binaries search directory to be provided.  This will make the db runner more flexible if someone decides to use it in some unpredictable way.