### PR TITLE
Fixed port lookup for UnixPortWatcher.

### DIFF
--- a/src/Mongo2Go/Helper/UnixPortWatcher.cs
+++ b/src/Mongo2Go/Helper/UnixPortWatcher.cs
@@ -27,21 +27,17 @@ namespace Mongo2Go.Helper
 
         public bool IsPortAvailable (int portNumber)
         {
-            bool result = false;
-
             TcpListener tcpListener = new TcpListener (IPAddress.Loopback, portNumber);
             try {                
                 tcpListener.Start ();
-            } catch (SocketException) {
-                result = false;
-
+                return true;
+            }
+            catch (SocketException) {
+                return false;
             } finally 
             {
                 tcpListener.Stop ();
-                result = true;
             }
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
On Linux environment always received port: 27018 and as a result "SocketException: Address already in use."
Root cause: `result = false` from catch block was overridden by finally block which always sets true.