### PR TITLE
Fixes a file path issue on Linux if you run on an sdk version beyond netstandard1.6

### DIFF
--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -4,7 +4,7 @@
     <metadata>
 
         <id>Mongo2Go-temp-linux-fix</id>
-        <version>0.0.4</version>
+        <version>0.0.5</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>

--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -3,16 +3,23 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
 
-        <id>Mongo2Go-temp-linux-fix</id>
-        <version>0.0.6</version>
+        <id>Mongo2Go</id>
+        <version>2.2.9</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>
 
-        <owners>Jeroen Vannevel</owners>
+        <owners>Johannes Hoppe</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-        <description>Temporary package to verify a fix in teamcity</description>
+        <description>Mongo2Go is a managed wrapper around the latest MongoDB binaries. It targets .NET Standard 1.6.
+This Nuget package contains the executables of mongod, mongoimport and mongoexport v3.6.1 for Windows, Linux and macOS.
+
+
+Mongo2Go has two use cases:
+
+1. Providing multiple, temporary and isolated MongoDB databases for unit tests (or to be precise: integration tests)
+2. Providing a quick to set up MongoDB database for a local developer environment</description>
 
         <language>en-US</language>
         <summary>MongoDB for integration tests and local debugging</summary>

--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -4,7 +4,7 @@
     <metadata>
 
         <id>Mongo2Go-temp-linux-fix</id>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>

--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -3,23 +3,16 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
 
-        <id>Mongo2Go</id>
-        <version>2.2.8</version>
+        <id>Mongo2Go-temp-linux-fix</id>
+        <version>0.0.1</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>
 
-        <owners>Johannes Hoppe</owners>
+        <owners>Jeroen Vannevel</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-        <description>Mongo2Go is a managed wrapper around the latest MongoDB binaries. It targets .NET Standard 1.6.
-This Nuget package contains the executables of mongod, mongoimport and mongoexport v3.6.1 for Windows, Linux and macOS.
-
-
-Mongo2Go has two use cases:
-
-1. Providing multiple, temporary and isolated MongoDB databases for unit tests (or to be precise: integration tests)
-2. Providing a quick to set up MongoDB database for a local developer environment</description>
+        <description>Temporary package to verify a fix in teamcity</description>
 
         <language>en-US</language>
         <summary>MongoDB for integration tests and local debugging</summary>
@@ -35,6 +28,6 @@ Mongo2Go has two use cases:
 
         <file src="src\Mongo2Go\bin\Release\**" target="lib" />
         <file src="tools\**" target="tools\" />
-        
+
     </files>
 </package>

--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -4,7 +4,7 @@
     <metadata>
 
         <id>Mongo2Go-temp-linux-fix</id>
-        <version>0.0.5</version>
+        <version>0.0.6</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>

--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -4,7 +4,7 @@
     <metadata>
 
         <id>Mongo2Go-temp-linux-fix</id>
-        <version>0.0.1</version>
+        <version>0.0.3</version>
 
         <title>Mongo2Go</title>
         <authors>Johannes Hoppe and many contributors</authors>

--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -12,7 +12,7 @@ namespace Mongo2Go.Helper
         private readonly string _nugetPrefix = Path.Combine("packages", "Mongo2Go*");
         private readonly string _nugetCachePrefix = Path.Combine("packages", "mongo2go", "*");
         public const string DefaultWindowsSearchPattern = @"tools\mongodb-win32*\bin";
-        public const string DefaultLinuxSearchPattern = "tools/mongodb-linux*/bin";
+        public const string DefaultLinuxSearchPattern = "*/tools/mongodb-linux*/bin";
         public const string DefaultOsxSearchPattern = "tools/mongodb-osx*/bin";
         public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
         public static readonly string OsxAndLinuxNugetCacheLocation = Environment.GetEnvironmentVariable("HOME") + "/.nuget/packages";

--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -15,7 +15,7 @@ namespace Mongo2Go.Helper
         public const string DefaultLinuxSearchPattern = "*/tools/mongodb-linux*/bin";
         public const string DefaultOsxSearchPattern = "tools/mongodb-osx*/bin";
         public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
-        public static readonly string OsxAndLinuxNugetCacheLocation = Environment.GetEnvironmentVariable("HOME") + "/.nuget/packages";
+        public static readonly string OsxAndLinuxNugetCacheLocation = Environment.GetEnvironmentVariable("HOME") + "/.nuget/packages/mongo2go";
         private string _binFolder = string.Empty;
         private readonly string _searchPattern;
         private readonly string _nugetCacheDirectory;

--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -15,7 +15,7 @@ namespace Mongo2Go.Helper
         public const string DefaultLinuxSearchPattern = "tools/mongodb-linux*/bin";
         public const string DefaultOsxSearchPattern = "tools/mongodb-osx*/bin";
         public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
-        public const string OsxAndLinuxNugetCacheLocation = "~/.nuget/packages";
+        public static readonly string OsxAndLinuxNugetCacheLocation = Environment.GetEnvironmentVariable("HOME") + "/.nuget/packages";
         private string _binFolder = string.Empty;
         private readonly string _searchPattern;
         private readonly string _nugetCacheDirectory;


### PR DESCRIPTION
This fixes the issue described in #62 using the solution provided in #61. @alexfowler09 was correct with his suggestion -- after applying the suggested changes, Linux worked both on my VM as well as my build server.

I'm unclear what changed inside the SDK to make it suddenly work. So far I haven't been able to pinpoint anything aside from the fact that it seemingly doesn't resolve the `~` as a relative path inside `Directory.GetDirectories(path)` and I'm unsure if this is a regression. Seeing as Mongo2Go points to netstandard1.6, it seems like it potentially is a change between netcore1.0 and netcore1.1/2.0. I'll give this further investigation but at least the most pressing issue is resolved.

It doesn't seem unreasonable that the Mac lookups might require similar changes but since I don't own a Mac, I can't try it out to verify. Will leave it as-is, I guess you'll see if someone complains about something similar.