### PR TITLE
Fixed bug with pulling mongo binaries from wrong version

### DIFF
--- a/src/Mongo2Go/Helper/FolderSearch.cs
+++ b/src/Mongo2Go/Helper/FolderSearch.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using MongoDB.Bson.Serialization.Serializers;
 
 namespace Mongo2Go.Helper
 {
@@ -25,7 +27,16 @@ namespace Mongo2Go.Helper
                 {
                     return null;
                 }
-                currentPath = matchesDirectory.OrderBy(x => x).Last();
+
+                if (matchesDirectory.Length > 1)
+                {
+                    currentPath = MatchVersionToAssemblyVersion(matchesDirectory)
+                        ?? matchesDirectory.OrderBy(x => x).Last();
+                }
+                else
+                {
+                    currentPath = matchesDirectory.First();
+                }
             }
 
             return currentPath;
@@ -67,11 +78,25 @@ namespace Mongo2Go.Helper
             }
             else
             {
-                finalPath = Path.Combine (CurrentExecutingDirectory (), fileName);
+                finalPath = Path.Combine(CurrentExecutingDirectory(), fileName);
                 finalPath = Path.GetFullPath(finalPath);
             }
 
             return finalPath;
+        }
+
+        private static string MatchVersionToAssemblyVersion(string[] folders)
+        {
+            var version = typeof(FolderSearch).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
+            foreach (var folder in folders)
+            {
+                var lastFolder = new DirectoryInfo(folder).Name;
+                if (lastFolder == version)
+                    return folder;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Mongo2GoTests/FolderSearchTests.cs
+++ b/src/Mongo2GoTests/FolderSearchTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using FluentAssertions;
 using Machine.Specifications;
 using Mongo2Go.Helper;
@@ -74,6 +75,33 @@ namespace Mongo2GoTests
 
         Because of = () => directory = "test1".RemoveLastPart();
         It should_return_null = () => directory.Should().BeNull();
+    }
+
+    [Subject("FolderSearch")]
+    public class when_directory_contains_multiple_versions_mongo2go
+    {
+        private readonly string[] directories;
+
+        public when_directory_contains_multiple_versions_mongo2go()
+        {
+            // setup two directories
+            directories = new[]
+            {
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "2.2.12a"),
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "2.2.9"),
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "2.2.12")
+            };
+
+            foreach (var d in directories)
+                Directory.CreateDirectory(d);
+        }
+
+        private static string path;
+
+        private Because of = () => path = FolderSearch.FindFolder(AppDomain.CurrentDomain.BaseDirectory, "*");
+
+        private It should_return_2212 =
+            () => path.Should().Be(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "2.2.12"));
     }
 
     public class FolderSearchSpec


### PR DESCRIPTION
If I have mongo2go 2.2.9 install and 2.2.12 and I am running 2.2.12 it pulls the binaries from 2.2.9 and fails because of the ssl mongo argument.  This pulls the binaries based on the version of mongo2go I am running.