### PR TITLE
MongoServer replaced with MongoClient in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ public class MongoIntegrationTest
     {
         _runner = MongoDbRunner.Start();
         
-        MongoServer server = MongoServer.Create(_runner.ConnectionString);
-        MongoDatabase database = server.GetDatabase("IntegrationTest");
+        MongoClient client = new MongoClient(_runner.ConnectionString);
+        MongoDatabase database = client.GetDatabase("IntegrationTest");
         _collection = database.GetCollection<TestDocument>("TestCollection");
     }
 }    
@@ -144,8 +144,8 @@ public class WebApiApplication : System.Web.HttpApplication
         _runner = MongoDbRunner.StartForDebugging();
         _runner.Import("TestDatabase", "TestCollection", @"..\..\App_Data\test.json", true);
 
-        MongoServer server = MongoServer.Create(_runner.ConnectionString);
-        MongoDatabase database = server.GetDatabase("TestDatabase");
+        MongoClient client = new MongoClient(_runner.ConnectionString);
+        MongoDatabase database = client.GetDatabase("TestDatabase");
         MongoCollection<TestObject> collection = database.GetCollection<TestObject>("TestCollection");
 
         /* happy coding! */


### PR DESCRIPTION
The `MongoServer.Create()` method was removed in [version 2.0](https://api.mongodb.com/csharp/2.0/html/T_MongoDB_Driver_MongoServer.htm). It has been deprecated since at least [version 1.7](https://api.mongodb.com/csharp/1.7/html/be930ec9-1678-e9b0-df2d-655be96a3747.htm).
Instead, [MongoClient](https://api.mongodb.com/csharp/2.0/html/T_MongoDB_Driver_MongoClient.htm) should be used.