### PR TITLE
throw exception if cluster not ready for transactions after `singleNodeReplSetWaitTimeout`

### DIFF
--- a/src/Mongo2Go/Helper/IMongoDbProcessStarter.cs
+++ b/src/Mongo2Go/Helper/IMongoDbProcessStarter.cs
@@ -2,8 +2,8 @@ namespace Mongo2Go.Helper
 {
     public interface IMongoDbProcessStarter
     {
-        IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = 5);
+        IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout);
 
-        IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool doNotKill, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = 5);
+        IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool doNotKill, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout);
     }
 }

--- a/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
+++ b/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
@@ -65,6 +65,11 @@ namespace Mongo2Go.Helper
                 // wait until replica set is ready or until the timeout is reached
                 SpinWait.SpinUntil(() => replicaSetReady, TimeSpan.FromSeconds(singleNodeReplSetWaitTimeout));
 
+                if (!replicaSetReady)
+                {
+                    throw new TimeoutException($"Replica set initialization took longer than the specified timeout of {singleNodeReplSetWaitTimeout} seconds. Please consider increasing the value of {nameof(singleNodeReplSetWaitTimeout)}.");
+                }
+
                 // wait until transaction is ready or until the timeout is reached
                 SpinWait.SpinUntil(() =>
                     client.Cluster.Description.Servers.Any(s => s.State == ServerState.Connected && s.IsDataBearing),

--- a/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
+++ b/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
@@ -19,7 +19,7 @@ namespace Mongo2Go.Helper
         /// <summary>
         /// Starts a new process. Process can be killed
         /// </summary>
-        public IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = 5)
+        public IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             return Start(binariesDirectory, dataDirectory, port, false, singleNodeReplSet, additionalMongodArguments, singleNodeReplSetWaitTimeout);
         }
@@ -27,7 +27,7 @@ namespace Mongo2Go.Helper
         /// <summary>
         /// Starts a new process.
         /// </summary>
-        public IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool doNotKill, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = 5)
+        public IMongoDbProcess Start(string binariesDirectory, string dataDirectory, int port, bool doNotKill, bool singleNodeReplSet, string additionalMongodArguments, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             string fileName = @"{0}{1}{2}".Formatted(binariesDirectory, System.IO.Path.DirectorySeparatorChar.ToString(), MongoDbDefaults.MongodExecutable);
 

--- a/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
+++ b/src/Mongo2Go/Helper/MongoDbProcessStarter.cs
@@ -75,9 +75,9 @@ namespace Mongo2Go.Helper
                     client.Cluster.Description.Servers.Any(s => s.State == ServerState.Connected && s.IsDataBearing),
                     TimeSpan.FromSeconds(singleNodeReplSetWaitTimeout));
 
-                if (!replicaSetReady)
+                if (!client.Cluster.Description.Servers.Any(s => s.State == ServerState.Connected && s.IsDataBearing))
                 {
-                    throw new TimeoutException($"Replica set initialization took longer than the specified timeout of {singleNodeReplSetWaitTimeout} seconds. Please consider increasing the value of {nameof(singleNodeReplSetWaitTimeout)}.");
+                    throw new TimeoutException($"Cluster readiness for transactions took longer than the specified timeout of {singleNodeReplSetWaitTimeout} seconds. Please consider increasing the value of {nameof(singleNodeReplSetWaitTimeout)}.");
                 }
             }
 

--- a/src/Mongo2Go/MongoDbDefaults.cs
+++ b/src/Mongo2Go/MongoDbDefaults.cs
@@ -16,5 +16,7 @@
         public const int TestStartPort = 27018;
 
         public const string Lockfile = "mongod.lock";
+
+        public const int SingleNodeReplicaSetWaitTimeout = 10;
     }
 }

--- a/src/Mongo2Go/MongoDbRunner.cs
+++ b/src/Mongo2Go/MongoDbRunner.cs
@@ -31,7 +31,7 @@ namespace Mongo2Go
         /// On dispose: kills them and deletes their data directory
         /// </summary>
         /// <remarks>Should be used for integration tests</remarks>
-        public static MongoDbRunner Start(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = 5)
+        public static MongoDbRunner Start(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             if (dataDirectory == null) {
                 dataDirectory = CreateTemporaryDataDirectory();
@@ -82,7 +82,7 @@ namespace Mongo2Go
         /// Should be used for local debugging only
         /// WARNING: one single instance on one single machine is not a suitable setup for productive environments!!!
         /// </remarks>
-        public static MongoDbRunner StartForDebugging(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null, bool singleNodeReplSet = false, int port = MongoDbDefaults.DefaultPort, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = 5)
+        public static MongoDbRunner StartForDebugging(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null, bool singleNodeReplSet = false, int port = MongoDbDefaults.DefaultPort, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             return new MongoDbRunner(
                 new ProcessWatcher(),
@@ -138,7 +138,7 @@ namespace Mongo2Go
         /// <summary>
         /// usage: local debugging
         /// </summary>
-        private MongoDbRunner(IProcessWatcher processWatcher, IPortWatcher portWatcher, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin, int port, string dataDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = 5)
+        private MongoDbRunner(IProcessWatcher processWatcher, IPortWatcher portWatcher, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin, int port, string dataDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             _fileSystem = fileSystem;
             _mongoBin = mongoBin;
@@ -175,7 +175,7 @@ namespace Mongo2Go
         /// <summary>
         /// usage: integration tests
         /// </summary>
-        private MongoDbRunner(IPortPool portPool, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin, string dataDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = 5)
+        private MongoDbRunner(IPortPool portPool, IFileSystem fileSystem, IMongoDbProcessStarter processStarter, IMongoBinaryLocator mongoBin, string dataDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout)
         {
             _fileSystem = fileSystem;
             _port = portPool.GetNextOpenPort();


### PR DESCRIPTION
The current logic only throws a timeout exception if the replica set is not ready after `singleNodeReplSetWaitTimeout` seconds.

A check for the cluster's readiness for transactions was added but nothing is done when the timeout expires. This pull request handles that.

Also, since it looks like this new check takes longer than the default timeout of 5 seconds, I increased the default timeout from `5` to `10` seconds.