### PR TITLE
Issue #42

### DIFF
--- a/src/Mongo2Go/Helper/FolderSearch.cs
+++ b/src/Mongo2Go/Helper/FolderSearch.cs
@@ -10,6 +10,8 @@ namespace Mongo2Go.Helper
 {
     public static class FolderSearch
     {
+        private static readonly char[] _separators = { Path.DirectorySeparatorChar };
+
         public static string CurrentExecutingDirectory()
         {
             string filePath = new Uri(typeof(FolderSearch).GetTypeInfo().Assembly.CodeBase).LocalPath;
@@ -18,10 +20,20 @@ namespace Mongo2Go.Helper
 
         public static string FindFolder(this string startPath, string searchPattern)
         {
+            if (startPath == null || searchPattern == null)
+            {
+                return null;
+            }
+
             string currentPath = startPath;
 
-            foreach (var part in searchPattern.Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.None))
+            foreach (var part in searchPattern.Split(_separators, StringSplitOptions.None))
             {
+                if (!Directory.Exists(currentPath))
+                {
+                    return null;
+                }
+
                 string[] matchesDirectory = Directory.GetDirectories(currentPath, part);
                 if (!matchesDirectory.Any())
                 {

--- a/src/Mongo2GoTests/FolderSearchTests.cs
+++ b/src/Mongo2GoTests/FolderSearchTests.cs
@@ -28,10 +28,22 @@ namespace Mongo2GoTests
         It should_find_the_path_with_the_highest_version_number = () => directory.Should().Be(MongoBinaries);
     }
 
+
     [Subject("FolderSearch")]
     public class when_searching_for_not_existing_folder : FolderSearchSpec
     {
         static string startDirectory = Path.Combine(BaseDir, "test1", "test2");
+        static string searchPattern = Path.Combine("packages", "Mongo2Go*", "XXX", "mongodb-win32-i386*", "bin");
+        static string directory;
+
+        Because of = () => directory = startDirectory.FindFolder(searchPattern);
+        It should_return_null = () => directory.Should().BeNull();
+    }
+
+    [Subject("FolderSearch")]
+    public class when_searching_for_not_existing_start_dir : FolderSearchSpec
+    {
+        static string startDirectory = Path.Combine(Path.GetRandomFileName());
         static string searchPattern = Path.Combine("packages", "Mongo2Go*", "XXX", "mongodb-win32-i386*", "bin");
         static string directory;
 


### PR DESCRIPTION
GetDirectories throws exception on non existing starting folder which prevents searching binaries at another folders and gives to user non informative error message.