### PR TITLE
Add support for NUGET_PACKAGES env var

### DIFF
--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -29,17 +29,17 @@ namespace Mongo2Go.Helper
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 _searchPattern = DefaultOsxSearchPattern;
-                _nugetCacheDirectory ??= OsxAndLinuxNugetCacheLocation;
+                _nugetCacheDirectory = _nugetCacheDirectory ?? OsxAndLinuxNugetCacheLocation;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 _searchPattern = DefaultLinuxSearchPattern;
-                _nugetCacheDirectory ??= OsxAndLinuxNugetCacheLocation;
+                _nugetCacheDirectory = _nugetCacheDirectory ?? OsxAndLinuxNugetCacheLocation;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _searchPattern = DefaultWindowsSearchPattern;
-                _nugetCacheDirectory ??= Environment.ExpandEnvironmentVariables(WindowsNugetCacheLocation);
+                _nugetCacheDirectory = _nugetCacheDirectory ?? Environment.ExpandEnvironmentVariables(WindowsNugetCacheLocation);
             }
             else
             {

--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -24,29 +24,29 @@ namespace Mongo2Go.Helper
         public MongoBinaryLocator(string searchPatternOverride, string additionalSearchDirectory)
         {
             _additionalSearchDirectory = additionalSearchDirectory;
-            if (string.IsNullOrEmpty(searchPatternOverride))
+            _nugetCacheDirectory = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    _searchPattern = DefaultOsxSearchPattern;
-                    _nugetCacheDirectory = OsxAndLinuxNugetCacheLocation;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    _searchPattern = DefaultLinuxSearchPattern;
-                    _nugetCacheDirectory = OsxAndLinuxNugetCacheLocation;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    _searchPattern = DefaultWindowsSearchPattern;
-                    _nugetCacheDirectory = Environment.ExpandEnvironmentVariables(WindowsNugetCacheLocation);
-                }
-                else
-                {
-                    throw new MonogDbBinariesNotFoundException($"Unknown OS: {RuntimeInformation.OSDescription}");
-                }
+                _searchPattern = DefaultOsxSearchPattern;
+                _nugetCacheDirectory ??= OsxAndLinuxNugetCacheLocation;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                _searchPattern = DefaultLinuxSearchPattern;
+                _nugetCacheDirectory ??= OsxAndLinuxNugetCacheLocation;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                _searchPattern = DefaultWindowsSearchPattern;
+                _nugetCacheDirectory ??= Environment.ExpandEnvironmentVariables(WindowsNugetCacheLocation);
             }
             else
+            {
+                throw new MonogDbBinariesNotFoundException($"Unknown OS: {RuntimeInformation.OSDescription}");
+            }
+
+            if (!string.IsNullOrEmpty(searchPatternOverride))
             {
                 _searchPattern = searchPatternOverride;
             }


### PR DESCRIPTION
This adds support for the environment variable `NUGET_PACKAGES`, which changes the location of the NuGet package cache.
Reference: https://docs.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-environment-variables

I also slightly changed the control flow in the `MongoBinaryLocator` constructor to ensure ensure that `_nugetCacheDirectory` is not null even when `searchPatternOverride` is specified.