### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/Mongo2Go.nuspec
+++ b/Mongo2Go.nuspec
@@ -12,7 +12,7 @@
         <owners>Johannes Hoppe</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
-        <description>Mongo2Go is a managed wrapper around the latest MongoDB binaries. It targets .NET Standard 2.1.
+        <description>Mongo2Go is a managed wrapper around the latest MongoDB binaries. It targets .NET Standard 2.0.
 This Nuget package contains the executables of mongod, mongoimport and mongoexport v4.4.4 for Windows, Linux and macOS.
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Mongo2Go - MongoDB for integration tests & local debugging
 
 
 Mongo2Go is a managed wrapper around the latest MongoDB binaries.
-It targets **.NET Standard 2.1** (and **.NET 4.6** for legacy environments) and works with Windows, Linux and macOS.
+It targets **.NET Standard 2.0** (and **.NET 4.6** for legacy environments) and works with Windows, Linux and macOS.
 This Nuget package contains the executables of _mongod_, _mongoimport_ and _mongoexport_ **for Windows, Linux and macOS** .
 
 __Brought to you by [Johannes Hoppe](https://haushoppe-its.de), follow him on [Twitter](https://twitter.com/johanneshoppe).__ 

--- a/src/Mongo2Go/Helper/NetStandard21Compatibility.cs
+++ b/src/Mongo2Go/Helper/NetStandard21Compatibility.cs
@@ -1,0 +1,24 @@
+#if NETSTANDARD2_0
+using System;
+
+namespace Mongo2Go.Helper
+{
+    public static class NetStandard21Compatibility
+    {
+        /// <summary>
+        /// Returns a value indicating whether a specified string occurs within this <paramref name="string"/>, using the specified comparison rules.
+        /// </summary>
+        /// <param name="string">The string to operate on.</param>
+        /// <param name="value">The string to seek.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+        /// <returns><see langword="true"/> if the <paramref name="value"/> parameter occurs within this string, or if <paramref name="value"/> is the empty string (""); otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/></exception>
+        public static bool Contains(this string @string, string value, StringComparison comparisonType)
+        {
+            if (@string == null) throw new ArgumentNullException(nameof(@string));
+
+            return @string.IndexOf(value, comparisonType) >= 0;
+        }
+    }
+}
+#endif

--- a/src/Mongo2Go/Mongo2Go.csproj
+++ b/src/Mongo2Go/Mongo2Go.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Mongo2Go - MongoDB for integration tests</Description>
     <Company>HAUS HOPPE - ITS</Company>
     <Copyright>Copyright © 2012-2021 Johannes Hoppe</Copyright>


### PR DESCRIPTION
Targeting .NET Standard 2.0 instead of 2.1 makes Mongo2Go compatible with.NET Framework (version 4.7.1 and later).