### PR TITLE
Fix #127

### DIFF
--- a/src/Mongo2Go/Helper/MongoBinaryLocator.cs
+++ b/src/Mongo2Go/Helper/MongoBinaryLocator.cs
@@ -13,7 +13,8 @@ namespace Mongo2Go.Helper
         private readonly string _nugetCachePrefix = Path.Combine("packages", "mongo2go", "*");
         private readonly string _nugetCacheBasePrefix = Path.Combine("mongo2go", "*");
         public const string DefaultWindowsSearchPattern = @"tools\mongodb-windows*\bin";
-        public const string DefaultLinuxSearchPattern = "*/tools/mongodb-linux*/bin";
+        public const string DefaultLinuxSearchPattern = "*/tools/mongodb-linux-*/bin";
+        public const string DefaultLinuxArmSearchPattern = "*/tools/mongodb-linuxarm64*/bin";
         public const string DefaultOsxSearchPattern = "tools/mongodb-macos*/bin";
         public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
         public static readonly string OsxAndLinuxNugetCacheLocation = Environment.GetEnvironmentVariable("HOME") + "/.nuget/packages/mongo2go";
@@ -34,7 +35,8 @@ namespace Mongo2Go.Helper
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                _searchPattern = DefaultLinuxSearchPattern;
+                _searchPattern = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? 
+                    DefaultLinuxArmSearchPattern : DefaultLinuxSearchPattern;
                 _nugetCacheDirectory = _nugetCacheDirectory ?? OsxAndLinuxNugetCacheLocation;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/MongoDownloader/DataModel.cs
+++ b/src/MongoDownloader/DataModel.cs
@@ -14,6 +14,8 @@ namespace MongoDownloader
         // ReSharper disable once InconsistentNaming
         macOS,
         Windows,
+        // ReSharper disable once InconsistentNaming
+        LinuxARM64
     }
 
     public enum Product

--- a/src/MongoDownloader/Options.cs
+++ b/src/MongoDownloader/Options.cs
@@ -31,7 +31,13 @@ namespace MongoDownloader
         /// <summary>
         /// The architecture of the archive to download.
         /// </summary>
-        public Regex Architecture { get; init; } = new("x86_64");
+        public IReadOnlyDictionary<Platform, Regex> Architecture { get; init; } = new Dictionary<Platform, Regex>
+        {
+            [Platform.Linux] = new("x86_64", RegexOptions.IgnoreCase),
+            [Platform.Windows] = new ("x86_64", RegexOptions.IgnoreCase),
+            [Platform.macOS] = new("x86_64", RegexOptions.IgnoreCase),
+            [Platform.LinuxARM64]= new("aarch64", RegexOptions.IgnoreCase)
+        };
 
         /// <summary>
         /// The edition of the archive to download.
@@ -47,6 +53,7 @@ namespace MongoDownloader
             [Platform.Linux] = new(@"ubuntu2004", RegexOptions.IgnoreCase),
             [Platform.macOS] = new(@"macOS", RegexOptions.IgnoreCase),
             [Platform.Windows] = new(@"windows", RegexOptions.IgnoreCase),
+            [Platform.LinuxARM64] = new(@"ubuntu2004", RegexOptions.IgnoreCase)
         };
 
         /// <summary>
@@ -57,12 +64,14 @@ namespace MongoDownloader
         /// </summary>
         public IReadOnlyDictionary<(Product, Platform), Regex> Binaries { get; init; } = new Dictionary<(Product, Platform), Regex>
         {
-            [(Product.CommunityServer, Platform.Linux)]   = new(@"bin/mongod"),
-            [(Product.CommunityServer, Platform.macOS)]   = new(@"bin/mongod"),
-            [(Product.CommunityServer, Platform.Windows)] = new(@"bin/mongod\.exe"),
-            [(Product.DatabaseTools,   Platform.Linux)]   = new(@"bin/(mongoexport|mongoimport)"),
-            [(Product.DatabaseTools,   Platform.macOS)]   = new(@"bin/(mongoexport|mongoimport)"),
-            [(Product.DatabaseTools,   Platform.Windows)] = new(@"bin/(mongoexport|mongoimport)\.exe"),
+            [(Product.CommunityServer, Platform.Linux)]      = new(@"bin/mongod"),
+            [(Product.CommunityServer, Platform.macOS)]      = new(@"bin/mongod"),
+            [(Product.CommunityServer, Platform.Windows)]    = new(@"bin/mongod\.exe"),
+            [(Product.CommunityServer, Platform.LinuxARM64)] = new(@"bin/mongod"),
+            [(Product.DatabaseTools,   Platform.Linux)]      = new(@"bin/(mongoexport|mongoimport)"),
+            [(Product.DatabaseTools,   Platform.macOS)]      = new(@"bin/(mongoexport|mongoimport)"),
+            [(Product.DatabaseTools,   Platform.Windows)]    = new(@"bin/(mongoexport|mongoimport)\.exe"),
+            [(Product.DatabaseTools,   Platform.LinuxARM64)] = new(@"bin/(mongoexport|mongoimport)"),
         };
 
         /// <summary>
@@ -74,12 +83,14 @@ namespace MongoDownloader
         public IReadOnlyDictionary<(Product, Platform), Regex> Licenses { get; init; } = new Dictionary<(Product, Platform), Regex>
         {
             // The regular expression matches anything at the zip top level, i.e. does not contain any slash (/) character
-            [(Product.CommunityServer, Platform.Linux)]   = new(@"^[^/]+$"),
-            [(Product.CommunityServer, Platform.macOS)]   = new(@"^[^/]+$"),
-            [(Product.CommunityServer, Platform.Windows)] = new(@"^[^/]+$"),
-            [(Product.DatabaseTools,   Platform.Linux)]   = new(@"^[^/]+$"),
-            [(Product.DatabaseTools,   Platform.macOS)]   = new(@"^[^/]+$"),
-            [(Product.DatabaseTools,   Platform.Windows)] = new(@"^[^/]+$"),
+            [(Product.CommunityServer, Platform.Linux)]      = new(@"^[^/]+$"),
+            [(Product.CommunityServer, Platform.macOS)]      = new(@"^[^/]+$"),
+            [(Product.CommunityServer, Platform.Windows)]    = new(@"^[^/]+$"),
+            [(Product.CommunityServer, Platform.LinuxARM64)] = new(@"^[^/]+$"),
+            [(Product.DatabaseTools,   Platform.Linux)]      = new(@"^[^/]+$"),
+            [(Product.DatabaseTools,   Platform.macOS)]      = new(@"^[^/]+$"),
+            [(Product.DatabaseTools,   Platform.Windows)]    = new(@"^[^/]+$"),
+            [(Product.DatabaseTools, Platform.LinuxARM64)]   = new(@"^[^/]+$"),
         };
     }
 }


### PR DESCRIPTION
This commit should add ARM support. Somewhat relevant is that if you want to run on a pi, you will still have to manually download and unzip mongo v4 to get work on less than ArmV8.

I don't really know how to test that the mongobinarylocator would work the same because I don't really know how to build the nuget package from source