### PR TITLE
Stops extra empty temporary data being generated

### DIFF
--- a/src/Mongo2Go/MongoDbRunner.cs
+++ b/src/Mongo2Go/MongoDbRunner.cs
@@ -37,7 +37,7 @@ namespace Mongo2Go
         public static MongoDbRunner Start(string dataDirectory = null, string binariesSearchPatternOverride = null, string binariesSearchDirectory = null, bool singleNodeReplSet = false, string additionalMongodArguments = null, ushort singleNodeReplSetWaitTimeout = MongoDbDefaults.SingleNodeReplicaSetWaitTimeout, ILogger logger = null)
         {
             if (dataDirectory == null) {
-                dataDirectory = CreateTemporaryDataDirectory();
+                dataDirectory = GetTemporaryDataDirectory();
             }
 
             // this is required to support multiple instances to run in parallel
@@ -166,7 +166,7 @@ namespace Mongo2Go
             }
 
             if (dataDirectory == null) {
-                dataDirectory = CreateTemporaryDataDirectory();
+                dataDirectory = GetTemporaryDataDirectory();
             }
 
             _fileSystem.CreateFolder(dataDirectory);
@@ -186,7 +186,7 @@ namespace Mongo2Go
             _mongoBin = mongoBin;
 
             if (dataDirectory == null) {
-                dataDirectory = CreateTemporaryDataDirectory();
+                dataDirectory = GetTemporaryDataDirectory();
             }
 
             MakeMongoBinarysExecutable();
@@ -215,10 +215,7 @@ namespace Mongo2Go
             }
         }
 
-        private static string CreateTemporaryDataDirectory() {
-            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(path);
-            return path;
-        }
+
+        private static string GetTemporaryDataDirectory() => Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
     }
 }


### PR DESCRIPTION
If no data directory is provided, the code uses a temporary directory. However when the temporary directory name is retrieved the directory was also created.

Later on in the code these directory names are modified to include the port and sometimes a random string. This means the temporary directory is never used in the orginal form and the clean code in dispose does not remove it.

This modification stops the generation of the original temporary folder so only the modified folder is created.

Fixes: #136 